### PR TITLE
Add minimal Vite React frontend

### DIFF
--- a/tariff-ui/.env
+++ b/tariff-ui/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=https://logistics-demo-api-ffc8c2euguh7dch5.eastus-01.azurewebsites.net

--- a/tariff-ui/.gitignore
+++ b/tariff-ui/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/tariff-ui/index.html
+++ b/tariff-ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tariff UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/tariff-ui/package.json
+++ b/tariff-ui/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "tariff-ui",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/tariff-ui/src/App.jsx
+++ b/tariff-ui/src/App.jsx
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+
+const defaultJson = '{\n  "commodity": "electronics",\n  "rate": 0.1\n}';
+
+export default function App() {
+  const [json, setJson] = useState(defaultJson);
+  const [status, setStatus] = useState('');
+  const [feed, setFeed] = useState([]);
+  const API = import.meta.env.VITE_API_URL;
+
+  const send = async () => {
+    try {
+      const body = JSON.parse(json);
+      const res = await fetch(`${API}/demo/send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setStatus('Sent!');
+    } catch (err) {
+      setStatus('Error: ' + err.message);
+    }
+  };
+
+  const loadFeed = async () => {
+    try {
+      const res = await fetch(`${API}/feed/latest`);
+      const data = await res.json();
+      setFeed(data);
+    } catch (err) {
+      setFeed([{ error: err.message }]);
+    }
+  };
+
+  useEffect(() => { loadFeed(); }, []);
+
+  return (
+    <div style={{ fontFamily: 'sans-serif', padding: '1rem' }}>
+      <h1>Tariff Events</h1>
+      <textarea
+        style={{ width: '100%', height: '100px' }}
+        value={json}
+        onChange={e => setJson(e.target.value)}
+      />
+      <div>
+        <button style={{ marginTop: '0.5rem' }} onClick={send}>Send to Event Hub</button>
+      </div>
+      {status && <p>{status}</p>}
+      <h2>Live Feed</h2>
+      <button onClick={loadFeed} style={{ marginBottom: '0.5rem' }}>Refresh</button>
+      <ul>
+        {feed.map((item, idx) => (
+          <li key={idx} style={{ wordBreak: 'break-all' }}>
+            {typeof item === 'object' ? JSON.stringify(item) : String(item)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/tariff-ui/src/main.jsx
+++ b/tariff-ui/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tariff-ui/vite.config.js
+++ b/tariff-ui/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold `tariff-ui` Vite React app
- add page to send tariff events and view live feed
- configure API URL via env and basic inline styling

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897ed9072f0832f8e54793c97330f73